### PR TITLE
Add new 'pause' switch to CLI, for pausing after every audit stage.

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -543,7 +543,7 @@ def audit(e, args):
         mid = e.mids[0]
         risk_bayes.tweak_all(e, mid)
 
-        if not input("Begin new audit stage? (y or n):").startswith('y'):
+        if args.pause and not input("Begin new audit stage? (y or n):").startswith('y'):
             break
         saved_state.write_intermediate_saved_state(e)
         time.sleep(2)              # to ensure next stage_time is new

--- a/cli.py
+++ b/cli.py
@@ -68,6 +68,10 @@ def parse_args():
                         action="store_true",
                         help="Run audit based on current info.")
 
+    parser.add_argument("--pause",
+                        action="store_true",
+                        help="Pause after each audit stage to obtain confirmation before proceedings.")
+
     args = parser.parse_args()
     # print("Command line arguments:", args)
     return args


### PR DESCRIPTION
Rather than have mandatory pausing, with user input required to
continue, this change makes it optional.  (Rather, pausing is by
default disabled, and using the --pause switch turns it on.)
The intent here is to allow an audit to run to completion without
user intervention, so we can do audits in nosetests.
