### PR TITLE
DOC: Add description of --pause switch causing pause after each audit stage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1638,6 +1638,7 @@ Here we assume the election data is in the directory
 | ``python3 multi.py --make_audit orders CO-2017-11`` | Produces initial audit order files  |
 | ``python3 multi.py --read_audited CO-2017-11``      | Reads and checks audited votes      |
 | ``python3 multi.py --audit CO-2017-11``             | Runs audit                          |
+| ``python3 multi.py --audit --pause CO-2017-11``     | Runs audit, pausing after each stage |
 
 You can also run
 


### PR DESCRIPTION
The --pause switch will cause the program to stop after each audit stage, asking for human input (y/n) before proceeding to the next stage.  For synthetic (generated) elections and audits in nose tests, pauses should not be needed or desirable.