### PR TITLE
ENH: Modify syn.py so that it erases only multi-related subdirs.

### DIFF
--- a/syn.py
+++ b/syn.py
@@ -142,9 +142,17 @@ def process_args(e, args):
     e.election_name = e.election_dirname
 
     dirpath = os.path.join(multi.ELECTIONS_ROOT, e.election_dirname)
+
     if os.path.exists(dirpath):
-        utils.mywarning("Existing directory {} erased.".format(dirpath))
-        shutil.rmtree(dirpath)
+        utils.mywarning("Erasing previous contents of directory {}.".format(dirpath))
+        subdirs = ["1-election-spec",
+                   "2-reported",
+                   "3-audit"]
+        for subdir in subdirs:
+            dirpathx = os.path.join(dirpath, subdir)
+            if os.path.exists(dirpathx):
+                shutil.rmtree(dirpathx)
+                utils.mywarning("Directory {} erased.".format(dirpathx))
     
     if args.syn_type == '1':                        
         syn1.generate_syn_type_1(e, args)


### PR DESCRIPTION
A previous change to syn.py added functionality that erases (completely)
a subdirectory of 'elections' if a (synthetic) election is being re-generated.
The current change only erases the subdirs:
        election-id/1-election-spec
        election-id/2-reported
        election-id/3-audit
This helps ensure that this erasure functionality doesn't wreak havoc somehow
if the wrong dirpath is given for the new directory somehow.  I.e., this is just
for safety.