### PR TITLE
Changed name of write_csv.py to csv_writers.py

### DIFF
--- a/csv_writers.py
+++ b/csv_writers.py
@@ -1,6 +1,6 @@
-# write_csv.py
+# csv_writers.py
 # Ronald L, Rivest
-# August 5, 2017
+# September 18, 2017
 # python3
 
 """

--- a/syn.py
+++ b/syn.py
@@ -26,7 +26,7 @@ import reported
 import syn1
 import syn2
 import utils
-import write_csv
+import csv_writers
 
 class Syn_Params(object):
     """ An object we can hang synthesis generation parameters off of. """

--- a/syn1.py
+++ b/syn1.py
@@ -22,7 +22,7 @@ import outcomes
 import reported
 import syn
 import utils
-import write_csv
+import csv_writers
 
 
 """
@@ -450,6 +450,6 @@ def generate_syn_type_1(e, args):
             print(key)
             print("    ", vars(e)[key])
     
-    write_csv.write_csv(e)
+    csv_writers.write_csv(e)
 
 

--- a/syn2.py
+++ b/syn2.py
@@ -19,7 +19,7 @@ import audit_orders
 import syn
 import syn1
 import utils
-import write_csv
+import csv_writers
 
 
 def process_spec(e, synpar, L):
@@ -176,6 +176,6 @@ def generate_syn_type_2(e, args):
             print(key)
             print("    ", vars(e)[key])
 
-    write_csv.write_csv(e)
+    csv_writers.write_csv(e)
 
 


### PR DESCRIPTION
Changed name of "write_csv.py" to "csv_writers.py" to go along with
file "csv_readers.py" in naming style.  Changes made to syn.py syn1.py, syn2.py
which import it.

