### PR TITLE
BUG: Fix filename for audit_order to contain date_time, not just date.

### DIFF
--- a/audit_orders.py
+++ b/audit_orders.py
@@ -85,7 +85,7 @@ def write_audit_order(e, pbcid):
     dirpath = os.path.join(multi.ELECTIONS_ROOT, e.election_dirname,
                            "3-audit", "32-audit-orders")
     os.makedirs(dirpath, exist_ok=True)
-    ds = utils.date_string()
+    ds = utils.datetime_string()
     safe_pbcid = ids.filename_safe(pbcid)
     filename = os.path.join(dirpath, "audit-order-"+safe_pbcid+"-"+ds+".csv")
     with open(filename, "w") as file:


### PR DESCRIPTION
The output of audit_orders.py was a filename that contained a date stamp, but
not a date_time stamp.  All other files produced here contain a date_time stamp.
This output was fixed to also output a date_time stamp.