### PR TITLE
BUG: cli.py fixed to set multi.ELECTIONS_ROOT, not cli.ELECTIONS_ROOT.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -83,7 +83,7 @@ def process_args(e, args):
 
     e.election_name = args.election_name
 
-    ELECTIONS_ROOT = args.elections_root
+    multi.ELECTIONS_ROOT = args.elections_root
 
     if args.set_audit_seed != None:
         audit.set_audit_seed(e, args.set_audit_seed)


### PR DESCRIPTION
Fixes a bug in cli.py: when ELECTIONS_ROOT is set via a command-line argument, the
global variable that should be set is multi.ELECTIONS_ROOT, but cli.py was only setting
cli.ELECTIONS_ROOT.  This is now fixed.