### PR TITLE
RFT: rename cli.py to cli_multi.py.

### DIFF
--- a/cli_multi.py
+++ b/cli_multi.py
@@ -1,6 +1,6 @@
-# cli.py
-# Ronald L. Rivest (with Karim Husayn Karimi)
-# July 22, 2017
+# cli_multi.py
+# Ronald L. Rivest
+# July 22, 2017 (rev. September 21, 2017)
 # python3
 
 """

--- a/multi.py
+++ b/multi.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import audit
-import cli
+import cli_multi
 import election_spec
 import outcomes
 import planner

--- a/multi.py
+++ b/multi.py
@@ -502,10 +502,10 @@ def main():
     utils.start_datetime_string = utils.datetime_string()
     print("Starting date-time:", utils.start_datetime_string)
 
-    args = cli.parse_args()
+    args = cli_multi.parse_args()
     e = Election()
     try:
-        cli.process_args(e, args)
+        cli_multi.process_args(e, args)
     finally:
         utils.close_myprint_files()
 


### PR DESCRIPTION
Changing name of cli.py to cli_multi.py.  We will later set up cli_syn.py for the syn top-level program.
