### PR TITLE
TST: Remove print statement from csv_readers; adjust test_csv_readers.

### DIFF
--- a/csv_readers.py
+++ b/csv_readers.py
@@ -50,7 +50,7 @@ def read_csv_file(filename, required_fieldnames=None, varlen=False):
     Read CSV file and check required fieldnames present; varlen if variable-length rows.
     """
 
-    print("Reading CSV file:", filename)
+    # print("Reading CSV file:", filename)
     with open(filename) as file:
         reader = csv.reader(file)
         rows = [row for row in reader]

--- a/tests/test_csv_readers.py
+++ b/tests/test_csv_readers.py
@@ -97,7 +97,6 @@ def test_csv_tooShortRow_varlen():
     s = f.getvalue()
 
     lines = [
-        "Reading CSV file: test_file.csv",
         "WARNING: Ignoring too-short row:{}\n".format(['1'])
     ]
     assert s == "\n".join(lines)
@@ -136,7 +135,6 @@ def test_csv_required_fieldname_missing():
     s = f.getvalue()
 
     lines = [
-        "Reading CSV file: test_file.csv",
         "FATAL ERROR: File {} has fieldnames {}, while {} are required. Missing {}.\n".format(
             test_filename, fieldnames, required_fieldnames, missing_fieldnames)
     ]
@@ -161,7 +159,6 @@ def test_csv_extra_required_fieldname():
     s = f.getvalue()
 
     lines = [
-        "Reading CSV file: test_file.csv",
         "WARNING: File {} has extra fieldnames (ignored): {}\n".format(test_filename, extra_fieldnames)
     ]
     assert s == "\n".join(lines)
@@ -181,7 +178,6 @@ def test_csv_duplicate_field():
     s = f.getvalue()
 
     lines = [
-        "Reading CSV file: test_file.csv",
         "FATAL ERROR: Duplicate field name:{}\n".format(['A', 'B', 'B'])
     ]
     assert s == "\n".join(lines)


### PR DESCRIPTION
No need for this routine to print out filename of what it is reading...  Should be "silent".
Adjusted test routine to not expect this output, either...