### PR TITLE
BUG: Fix reported outcome bug in syn2.py.

### DIFF
--- a/elections/syn2_specs/4-easy.csv
+++ b/elections/syn2_specs/4-easy.csv
@@ -1,0 +1,3 @@
+Contest,    Collection,    Reported Vote,    Actual Vote,  Number
+Mayor,      PBC1,          Bob,              Bob,          5100
+Mayor,      PBC1,          Alice,            Alice,        4900

--- a/syn2.py
+++ b/syn2.py
@@ -57,7 +57,7 @@ def process_spec(e, synpar, L):
             e.params_c[cid] = ""
             e.write_ins_c[cid] = "no"
             e.selids_c[cid] = {}
-            e.ro_c[cid] = ("Alice",)     # FIX
+            e.ro_c[cid] = av      # first av becomes reported outcome
             mid = "M{}-{}".format(len(e.cids), cid)
             e.mids.append(mid)
             e.cid_m[mid] = cid


### PR DESCRIPTION
syn2 always reported "(Alice,)" as the reported winner for any contest.
syn2 adjusted to report as winner the actual vote for the first row mentioned for the contest.
