### PR TITLE
DOC: added internal documentation to syn2.py about winners.

### DIFF
--- a/syn2.py
+++ b/syn2.py
@@ -1,6 +1,6 @@
 # syn2.py
 # Ronald L. Rivest
-# August 5, 2017
+# August 5, 2017 (rev. Sep. 22, 2017)
 # python3
 
 """
@@ -46,6 +46,10 @@ def process_spec(e, synpar, L):
         signifying that they can't win the contest.
     The votes rv and av are arbitrary tuples, and may contain
     0, 1, 2, or more selection ids.
+
+    The FIRST av for a given contest becomes the "reported winner" 
+    for that contest, even if "num" is zero for that row or if the
+    reported or actual votes don't show that vote as the "winner".
     """
 
     for (cid, pbcid, rv, av, num) in L:


### PR DESCRIPTION
Expanded comment within syn2.py for routine process_spec to
indicate that the reported winner for a contest is equal to the actual
vote for the FIRST row for that contest in the spec.
