### PR TITLE
BUG: remove warnings_given counter from utils.py.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -83,7 +83,9 @@ def mywarning(msg):
     """
 
     global warnings_given
-    warnings_given += 1
+    # kill counter for now; it causes some problems with nosetests
+    # and in any case we'll be moving over to warnings.warn instead of mywarning.
+    # warnings_given += 1
     print("WARNING:", msg)
 
 


### PR DESCRIPTION
Keeping global track of the number of warnings given causes problems
with nosetests, which causes warnings to be given intentionally...
This change just kills the "+1" counter opn for utils.mywarning, so the counter
stays at 0.
Later, we'll want to change the code to use warnings.warn instead of utils.mywarning.
