### PR TITLE
Fixes to use audit seed properly

### DIFF
--- a/code/audit.py
+++ b/code/audit.py
@@ -76,7 +76,7 @@ def draw_sample(e):
             e.sn_tcpr[e.stage_time][cid][pbcid] = {}
 
             sample_size = int(e.sn_tp[e.stage_time][pbcid])
-            sample_bids = e.bids_p[pbcid][:sample_size]
+            sample_bids = e.shuffled_bids_p[pbcid][:sample_size]
 
             avs = []
             rvs = []
@@ -501,7 +501,7 @@ def write_audit_output_collection_status(e):
         file.write("\n")
         for pbcid in e.pbcids:
             file.write("{},".format(pbcid))
-            file.write("{},".format(len(e.bids_p[pbcid])))
+            file.write("{},".format(len(e.shuffled_bids_p[pbcid])))
             file.write("{},".format(e.sn_tp[e.stage_time][pbcid]))
             if "sn_tp" in e.saved_state:
                 new_sample_size = e.sn_tp[e.stage_time][pbcid]

--- a/code/cli_OpenAuditTool.py
+++ b/code/cli_OpenAuditTool.py
@@ -135,6 +135,7 @@ def dispatch(e, args):
     elif args.make_audit_orders:
         logger.info("make_audit_orders")
         audit_orders.compute_audit_orders(e)
+        audit_orders.write_audit_orders(e)
 
     elif args.read_audited:
         logger.info("read_audited--NO-OP-TBD")
@@ -142,6 +143,7 @@ def dispatch(e, args):
     elif args.audit:
         election_spec.read_election_spec(e)
         reported.read_reported(e)
+        audit_orders.compute_audit_orders(e)
         audit.audit(e, args)
 
 


### PR DESCRIPTION
Modified cli_OpenAuditTool.py to compute audit order every time we audit and modifies audit.py to read the shuffled order of the ballots. This fixes the issue where all seeds behave the same way, during the audit.