### PR TITLE
Fix header typo: "Number of allots sampled total"

### DIFF
--- a/code/audit.py
+++ b/code/audit.py
@@ -495,7 +495,7 @@ def write_audit_output_collection_status(e):
     with open(filename, "w") as file:
         fieldnames = ["Collection",
                       "Number of ballots",
-                      "Number of allots sampled total",
+                      "Number of ballots sampled total",
                       "Number of ballots sample this stage."]
         file.write(",".join(fieldnames))
         file.write("\n")


### PR DESCRIPTION
I've only fixed it where it is generated in the audit.py code.

The typos also show up in example output runs like
 `elections/*/3-audit/34-audit-output/audit-output-collection-status-*.csv`
and I'm not sure why so many of those files are being retained.

Having one or two as test outputs might be nice.